### PR TITLE
feat: cleanup method and publish prefix

### DIFF
--- a/tovald/conf.py
+++ b/tovald/conf.py
@@ -18,11 +18,11 @@ confluence_publish_force = True
 confluence_page_hierarchy = True
 confluence_disable_notifications = True
 confluence_disable_autogen_title = True
-
 confluence_server_url = getenv("CONFLUENCE_SERVER_URL")
 confluence_space_key = getenv("CONFLUENCE_SPACE_KEY")
 confluence_parent_page = getenv("CONFLUENCE_PARENT_PAGE")
 confluence_publish_token = getenv("CONFLUENCE_PAT")
+confluence_publish_prefix = getenv("CONFLUENCE_PUBLISH_PREFIX")
 
 confluence_page_generation_notice = True
 confluence_sourcelink = {}

--- a/tovald/main.py
+++ b/tovald/main.py
@@ -8,6 +8,8 @@ from tempfile import mkdtemp
 
 from jinja2 import Template
 from sphinx.application import Sphinx
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceError
+from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
 
 from tovald import __version__
 
@@ -89,15 +91,15 @@ def toctree_indexer(path: Path) -> None:
             index.write(toctree)
 
 
-def publish(path: Path) -> None:
-    """Publish sphinx-formatted documentation.
+def make_sphinx(path: Path) -> Sphinx:
+    """Create Sphinx application instance.
 
     Args:
     ----
-        path (Path): sphinx documentation tree root path
+        path (Path): documentation tree root path
 
     """
-    app = Sphinx(
+    return Sphinx(
         srcdir=path,
         confdir=path,
         doctreedir=path / "_doctree",
@@ -106,7 +108,48 @@ def publish(path: Path) -> None:
         freshenv=True,
     )
 
+
+def publish(path: Path) -> None:
+    """Publish sphinx-formatted documentation.
+
+    Args:
+    ----
+        path (Path): sphinx documentation tree root path
+
+    """
+    app = make_sphinx(path)
     app.build(force_all=True)
+
+
+def cleanup(path: Path) -> None:
+    """Clean up Confluence parent page by removing all child pages.
+
+    Args:
+    ----
+        path (Path): documentation path
+
+    """
+    app = make_sphinx(path)
+
+    try:
+        if not (publisher := getattr(app.builder, "publisher", None)):
+            publisher = ConfluencePublisher()
+            publisher.init(app.config)
+
+        publisher.connect()
+
+        if not (parent_id := publisher.get_base_page_id()):
+            panic("No parent page configured or found")
+
+        # Get and remove all child pages
+        if child_pages := publisher.get_descendants(parent_id, "search-aggressive"):
+            print(f"Removing {len(child_pages)} pages...")
+            [publisher.remove_page(page_id) for page_id in child_pages]
+            print("Cleanup completed successfully")
+        else:
+            print("No child pages found to remove")
+    except ConfluenceError as e:
+        panic(f"Cleanup failed: {e}")
 
 
 def main() -> None:
@@ -115,6 +158,7 @@ def main() -> None:
 
     parser.add_argument("DOCUMENTATION")
     parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {__version__}")
+    parser.add_argument("-c", "--cleanup", action="store_true")
     args = parser.parse_args()
 
     documentation = Path(args.DOCUMENTATION)
@@ -124,7 +168,10 @@ def main() -> None:
     shutil.copytree(documentation, output_directory, dirs_exist_ok=True)
 
     build_sphinx_tree(output_directory)
-    publish(output_directory)
+    if args.cleanup:
+        cleanup(output_directory)
+    else:
+        publish(output_directory)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
hello,

I submit a PR to add two new features:
- add a cleanup argument
- add a publication prefix

Build execution logs :

```
❯ uv run tovald docs
Running Sphinx v8.1.0
loading translations [en]... done
making output directory... done
myst v4.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=6, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
building [mo]: all of 0 po files
writing output... 
building [confluence]: all source files
updating environment: [new config] 2 added, 0 changed, 0 removed
reading sources... [100%] test/index
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... 
copying assets: done
writing output... [100%] test/index
publishing documents... [100%] test/index
building intersphinx... done
publishing assets... [100%] objects.inv
Publish point: https://confluence.company.internal/pages/viewpage.action?pageId=1234
build succeeded.
```

Cleanup executions logs :

```
❯ uv run tovald docs --cleanup
Running Sphinx v8.1.0
loading translations [en]... done
making output directory... done
myst v4.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=6, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
Removing 2 pages...
Cleanup completed successfully
```